### PR TITLE
use 1 thread in MultiClientTest

### DIFF
--- a/src/test/java/com/teragrep/rlp_03/MultiClientTest.java
+++ b/src/test/java/com/teragrep/rlp_03/MultiClientTest.java
@@ -104,7 +104,7 @@ public class MultiClientTest extends Thread{
     public void init() throws IOException, InterruptedException {
         port = getPort();
         server = new Server(port, new SyslogFrameProcessor(messageList::add));
-        server.setNumberOfThreads(4);
+        server.setNumberOfThreads(1);
         server.start();
         Thread.sleep(10);
     }


### PR DESCRIPTION
 Multi-Threading is not supported on Java 1.8