### PR TITLE
replace String step from toInt() FragmentImpl method with a CharBuffer.

### DIFF
--- a/src/main/java/com/teragrep/rlp_03/context/frame/fragment/FragmentImpl.java
+++ b/src/main/java/com/teragrep/rlp_03/context/frame/fragment/FragmentImpl.java
@@ -100,17 +100,38 @@ public class FragmentImpl implements Fragment {
     }
 
     /**
-     * Converts a char[] array to an int
-     * @param arr Character array containing chars for int
+     * Converts a char[] array filled with numeric ASCII codes to an integer
+     * @param arr Character array containing ASCII chars for int
      * @return integer
      */
-    private int charArrayToInt(char[] arr) {
+    protected int charArrayToInt(char[] arr) {
         int rv = 0;
+        boolean isNegative = false;
 
-        for (char c : arr) {
-            int digit = c - '0';
-            rv *= 10;
-            rv += digit;
+        for (int i = 0; i < arr.length; i++) {
+            if (i == 0 && arr[i] == '-') {
+                // check first char for '-'
+                isNegative = true;
+            }
+            else if (arr[i] >= '0' && arr[i] <= '9') {
+                // 0-9 are between 47 < c < 58 in ASCII table
+                // convert ASCII value to actual int value
+                int digit = arr[i] - '0';
+                rv *= 10;
+                rv += digit;
+
+                if (rv < 0 && !isNegative) {
+                    // if value is negative without '-' there was overflow
+                    throw new IllegalStateException("Integer overflow!");
+                }
+            } else {
+                throw new IllegalStateException("Unexpected character encountered: " + arr[i]);
+            }
+        }
+
+        // change value to negative if '-' was present
+        if (isNegative) {
+            rv = -1 * rv;
         }
 
         return rv;

--- a/src/main/java/com/teragrep/rlp_03/context/frame/fragment/FragmentImpl.java
+++ b/src/main/java/com/teragrep/rlp_03/context/frame/fragment/FragmentImpl.java
@@ -1,10 +1,16 @@
 package com.teragrep.rlp_03.context.frame.fragment;
 
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
+import java.util.stream.IntStream;
 
 public class FragmentImpl implements Fragment {
 
@@ -80,8 +86,34 @@ public class FragmentImpl implements Fragment {
     }
     @Override
     public int toInt() {
-        String integerString = toString();
-        return Integer.parseInt(integerString);
+        byte[] bytes = toBytes();
+        // initialize UTF-8 decoder
+        final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        try {
+            // decode utf-8 byte representation
+            CharBuffer charBuf = decoder.decode(ByteBuffer.wrap(bytes));
+            // convert char[] to int
+            return charArrayToInt(charBuf.array());
+        } catch (CharacterCodingException e) {
+            throw new RuntimeException("Character decoding error on toInt call: ", e);
+        }
+    }
+
+    /**
+     * Converts a char[] array to an int
+     * @param arr Character array containing chars for int
+     * @return integer
+     */
+    private int charArrayToInt(char[] arr) {
+        int rv = 0;
+
+        for (char c : arr) {
+            int digit = c - '0';
+            rv *= 10;
+            rv += digit;
+        }
+
+        return rv;
     }
 
     @Override

--- a/src/test/java/com/teragrep/rlp_03/context/frame/fragment/FragmentToIntTest.java
+++ b/src/test/java/com/teragrep/rlp_03/context/frame/fragment/FragmentToIntTest.java
@@ -1,0 +1,83 @@
+package com.teragrep.rlp_03.context.frame.fragment;
+
+import com.teragrep.rlp_03.context.frame.function.TransactionFunction;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FragmentToIntTest {
+    @Test
+    public void fragmentToIntTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        Fragment fragment = new FragmentImpl(transactionFunction);
+
+        String txn = "12345 ";
+        byte[] txnBytes = txn.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(txnBytes.length);
+        byteBuffer.put(txnBytes);
+        byteBuffer.flip();
+
+        fragment.accept(byteBuffer);
+
+        assertEquals(12345, fragment.toInt());
+    }
+
+    @Test
+    public void fragmentToIntOverflowTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        Fragment fragment = new FragmentImpl(transactionFunction);
+
+        String txn = String.valueOf(Integer.MAX_VALUE+1).concat(" ");
+        byte[] txnBytes = txn.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(txnBytes.length);
+        byteBuffer.put(txnBytes);
+        byteBuffer.flip();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> fragment.accept(byteBuffer), "payloadLength too long");
+    }
+
+    @Test
+    public void fragmentToIntMaxValueTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        Fragment fragment = new FragmentImpl(transactionFunction);
+
+        String txn = String.valueOf(Integer.MAX_VALUE).concat(" ");
+        byte[] txnBytes = txn.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(txnBytes.length);
+        byteBuffer.put(txnBytes);
+        byteBuffer.flip();
+
+        fragment.accept(byteBuffer);
+        assertEquals(Integer.MAX_VALUE, fragment.toInt());
+    }
+
+    @Test
+    public void charArrayToIntTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        FragmentImpl fragment = new FragmentImpl(transactionFunction);
+        assertEquals(1709, fragment.charArrayToInt(new char[]{'1', '7', '0', '9'}));
+    }
+
+    @Test
+    public void charArrayToIntNonNumericTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        FragmentImpl fragment = new FragmentImpl(transactionFunction);
+        assertThrows(IllegalStateException.class, () -> fragment.charArrayToInt(new char[]{'1', '7', 'A', '5'}),
+                "Unexpected character encountered: A");
+    }
+
+    @Test
+    public void charArrayToIntOverflowTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        FragmentImpl fragment = new FragmentImpl(transactionFunction);
+        // build overflowing char array
+        final String base = String.valueOf((long) Integer.MAX_VALUE + 1L);
+        assertThrows(IllegalStateException.class, () -> fragment.charArrayToInt(base.toCharArray()),
+                "Integer overflow!");
+    }
+}

--- a/src/test/java/com/teragrep/rlp_03/context/frame/fragment/FragmentToIntTest.java
+++ b/src/test/java/com/teragrep/rlp_03/context/frame/fragment/FragmentToIntTest.java
@@ -62,6 +62,12 @@ public class FragmentToIntTest {
         FragmentImpl fragment = new FragmentImpl(transactionFunction);
         assertEquals(1709, fragment.charArrayToInt(new char[]{'1', '7', '0', '9'}));
     }
+    @Test
+    public void charArrayToNegativeIntTest() {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        FragmentImpl fragment = new FragmentImpl(transactionFunction);
+        assertEquals(-1709, fragment.charArrayToInt(new char[]{'-', '1', '7', '0', '9'}));
+    }
 
     @Test
     public void charArrayToIntNonNumericTest() {

--- a/src/test/java/com/teragrep/rlp_03/context/frame/fragment/ManualFragmentPerformanceTest.java
+++ b/src/test/java/com/teragrep/rlp_03/context/frame/fragment/ManualFragmentPerformanceTest.java
@@ -1,0 +1,87 @@
+package com.teragrep.rlp_03.context.frame.fragment;
+
+import com.teragrep.rlp_03.context.frame.function.TransactionFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfSystemProperty(named="runFragmentPerformanceTest", matches = "true")
+public class ManualFragmentPerformanceTest {
+    private final int loops = 100_000_000;
+
+    @Test
+    public void positiveToIntPerformanceTest() {
+        int expected = 123_456_789;
+        Fragment fragment = createFragment(String.valueOf(expected));
+        Instant start = Instant.now();
+        for(int i=0; i<loops; i++) {
+            assertEquals(expected, fragment.toInt());
+        }
+        Instant end = Instant.now();
+        printStats("positiveToIntPerformanceTest", start, end);
+    }
+
+    @Test
+    public void negativeToIntPerformanceTest() {
+        int expected = -123_456_789;
+        Fragment fragment = createFragment(String.valueOf(expected));
+        Instant start = Instant.now();
+        for(int i=0; i<loops; i++) {
+            assertEquals(expected, fragment.toInt());
+        }
+        Instant end = Instant.now();
+        printStats("negativeToIntPerformanceTest", start, end);
+    }
+
+    @Test
+    public void toStringPerformanceTest() {
+        String expected = "123456789";
+        Fragment fragment = createFragment(expected);
+        Instant start = Instant.now();
+        for(int i=0; i<loops; i++) {
+            assertEquals(expected, fragment.toString());
+        }
+        Instant end = Instant.now();
+        printStats("toStringPerformanceTest", start, end);
+    }
+
+    @Test
+    public void toBytesPerformanceTest() {
+        String input = "123456789";
+        byte[] expected = input.getBytes();
+        Fragment fragment = createFragment(input);
+        Instant start = Instant.now();
+        for(int i=0; i<loops; i++) {
+            assertArrayEquals(expected, fragment.toBytes());
+        }
+        Instant end = Instant.now();
+        printStats("toBytesPerformanceTest", start, end);
+    }
+
+    private Fragment createFragment(String input) {
+        TransactionFunction transactionFunction = new TransactionFunction();
+        FragmentImpl fragment = new FragmentImpl(transactionFunction);
+        String txn = String.valueOf(input).concat(" ");
+        byte[] txnBytes = txn.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(txnBytes.length);
+        byteBuffer.put(txnBytes);
+        byteBuffer.flip();
+        fragment.accept(byteBuffer);
+        return fragment;
+    }
+
+    private void printStats(String caller, Instant start, Instant end) {
+        float elapsed = (float) Duration.between(start, end).toMillis()/1000;
+        int eps = (int) (loops/elapsed);
+        System.out.printf("[%s] Executed %,d loops in %.2f seconds (%,d eps)%n", caller, loops, elapsed, eps);
+    }
+}


### PR DESCRIPTION
Previously, toString() was used in toInt() to first convert the byte array to UTF-8 string and integer was parsed from that string.

With these changes, the byte array is decoded with UTF-8 decoder and then the resulting char array is converted to integer.

(#60 )