### PR TITLE
Adds rlp_09 manual benchmarking test for multiple input/output thread combinations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
         </dependency>
         <!-- testing -->
         <dependency>
+            <groupId>com.teragrep</groupId>
+            <artifactId>rlp_09</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.9.0</version>
@@ -84,6 +90,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.9.0</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.teragrep</groupId>
             <artifactId>rlp_09</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
+++ b/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
@@ -93,7 +93,8 @@ public class ManualBenchmarkTest {
         serverThread.start();
         relpFlooder.start();
         server.stop();
-        LOGGER.info(String.format("%22s%15s", "Flooder", "Server"));
+        // Some magical numbers for aligning outputs, ;;__;;
+        LOGGER.info(String.format("%22s%14s", "Flooder", "Server"));
         LOGGER.info(String.format("%-15s%,-15d%,d", "Threads", flooderThreads, serverThreads));
         LOGGER.info(String.format("%-15s%,-15d%,d", "Events", relpFlooder.getMessagesSent(), frameConsumer.atomicLong.get()));
         LOGGER.info(String.format("%-15s%,-15d%,d", "EPS", relpFlooder.getMessagesSent()/testDuration, frameConsumer.atomicLong.get()/testDuration));

--- a/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
+++ b/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
@@ -96,9 +96,9 @@ public class ManualBenchmarkTest {
         // Some magical numbers for aligning outputs, ;;__;;
         LOGGER.info(String.format("%22s%14s", "Flooder", "Server"));
         LOGGER.info(String.format("%-15s%,-15d%,d", "Threads", flooderThreads, serverThreads));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "Events", relpFlooder.getMessagesSent(), frameConsumer.atomicLong.get()));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "EPS", relpFlooder.getMessagesSent()/testDuration, frameConsumer.atomicLong.get()/testDuration));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "EPS/thread", relpFlooder.getMessagesSent()/testDuration/flooderThreads, frameConsumer.atomicLong.get()/testDuration/serverThreads));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "Records", relpFlooder.getTotalRecordsSent(), frameConsumer.atomicLong.get()));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS", relpFlooder.getTotalRecordsSent()/testDuration, frameConsumer.atomicLong.get()/testDuration));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS/thread", relpFlooder.getTotalRecordsSent()/testDuration/flooderThreads, frameConsumer.atomicLong.get()/testDuration/serverThreads));
     }
 
     private static class FrameConsumer implements Consumer<FrameContext> {

--- a/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
+++ b/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
@@ -93,20 +93,11 @@ public class ManualBenchmarkTest {
         serverThread.start();
         relpFlooder.start();
         server.stop();
-        LOGGER.info(
-                "Sent <{}> messages with <{}> threads ({} EPS / {} per thread)",
-                relpFlooder.getMessagesSent(),
-                flooderThreads,
-                relpFlooder.getMessagesSent()/testDuration,
-                relpFlooder.getMessagesSent()/testDuration/flooderThreads
-        );
-        LOGGER.info(
-                "Received <{}> messages with <{}> threads ({} EPS / {} per thread)",
-                frameConsumer.atomicLong.get(),
-                serverThreads,
-                frameConsumer.atomicLong.get()/testDuration,
-                frameConsumer.atomicLong.get()/testDuration/serverThreads
-        );
+        LOGGER.info(String.format("%22s%15s", "Flooder", "Server"));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "Threads", flooderThreads, serverThreads));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "Events", relpFlooder.getMessagesSent(), frameConsumer.atomicLong.get()));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "EPS", relpFlooder.getMessagesSent()/testDuration, frameConsumer.atomicLong.get()/testDuration));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "EPS/thread", relpFlooder.getMessagesSent()/testDuration/flooderThreads, frameConsumer.atomicLong.get()/testDuration/serverThreads));
     }
 
     private static class FrameConsumer implements Consumer<FrameContext> {

--- a/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
+++ b/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
@@ -1,0 +1,119 @@
+/*
+ * Java Reliable Event Logging Protocol Library Server Implementation RLP-03
+ * Copyright (C) 2021  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.rlp_03;
+
+import com.teragrep.rlp_03.config.Config;
+import com.teragrep.rlp_09.RelpFlooder;
+import com.teragrep.rlp_09.RelpFlooderConfig;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ManualBenchmarkTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManualBenchmarkTest.class);
+    private final int port = 1601;
+    private final int testDuration = 60;
+
+    @ParameterizedTest
+    @EnabledIfSystemProperty(named="runManualBenchmarkTest", matches="true")
+    @CsvSource({"1,1", "2,2", "4,4", "8,8", "1,4", "4,1", "2,4", "4,2"}) // Pairs of flooderThreads:serverThreads
+    public void runBenchmarkTest(int flooderThreads, int serverThreads) throws IOException {
+        LOGGER.info("Running <{}> server and <{}> input threads test for <{}> seconds", flooderThreads, serverThreads, testDuration);
+        RelpFlooderConfig relpFlooderConfig = new RelpFlooderConfig();
+        relpFlooderConfig.setPort(port);
+        relpFlooderConfig.setThreads(flooderThreads);
+        RelpFlooder relpFlooder = new RelpFlooder(relpFlooderConfig);
+        Config config = new Config(port, serverThreads);
+        FrameConsumer frameConsumer = new FrameConsumer();
+        Supplier<FrameProcessor> frameProcessorSupplier = () -> new SyslogFrameProcessor(frameConsumer);
+
+        ServerFactory serverFactory = new ServerFactory(config, frameProcessorSupplier);
+        Server server = serverFactory.create();
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                relpFlooder.stop();
+            }
+        }, testDuration*1000);
+
+        Thread serverThread = new Thread(server);
+        serverThread.start();
+        relpFlooder.start();
+        server.stop();
+        LOGGER.info(
+                "Sent <{}> messages with <{}> threads ({} EPS / {} per thread)",
+                relpFlooder.getMessagesSent(),
+                flooderThreads,
+                relpFlooder.getMessagesSent()/testDuration,
+                relpFlooder.getMessagesSent()/testDuration/flooderThreads
+        );
+        LOGGER.info(
+                "Received <{}> messages with <{}> threads ({} EPS / {} per thread)",
+                frameConsumer.atomicLong.get(),
+                serverThreads,
+                frameConsumer.atomicLong.get()/testDuration,
+                frameConsumer.atomicLong.get()/testDuration/serverThreads
+        );
+    }
+
+    private static class FrameConsumer implements Consumer<FrameContext> {
+        final AtomicLong atomicLong = new AtomicLong();
+        @Override
+        public void accept(FrameContext frameServerRX) {
+            atomicLong.incrementAndGet();
+        }
+    }
+}

--- a/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
+++ b/src/test/java/com/teragrep/rlp_03/ManualBenchmarkTest.java
@@ -96,16 +96,20 @@ public class ManualBenchmarkTest {
         // Some magical numbers for aligning outputs, ;;__;;
         LOGGER.info(String.format("%22s%14s", "Flooder", "Server"));
         LOGGER.info(String.format("%-15s%,-15d%,d", "Threads", flooderThreads, serverThreads));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "Records", relpFlooder.getTotalRecordsSent(), frameConsumer.atomicLong.get()));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS", relpFlooder.getTotalRecordsSent()/testDuration, frameConsumer.atomicLong.get()/testDuration));
-        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS/thread", relpFlooder.getTotalRecordsSent()/testDuration/flooderThreads, frameConsumer.atomicLong.get()/testDuration/serverThreads));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "Records", relpFlooder.getTotalRecordsSent(), frameConsumer.receivedRecords.get()));
+        LOGGER.info(String.format("%-15s%,-15.2f%,.2f", "Megabytes", relpFlooder.getTotalBytesSent()/1024f/1024f, frameConsumer.receivedBytes.get()/1024f/1024f));
+        LOGGER.info(String.format("%-15s%,-15.2f%,.2f", "Megabytes/s", relpFlooder.getTotalBytesSent()/1024f/1024f/testDuration, frameConsumer.receivedBytes.get()/1024f/1024f/testDuration));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS", relpFlooder.getTotalRecordsSent()/testDuration, frameConsumer.receivedRecords.get()/testDuration));
+        LOGGER.info(String.format("%-15s%,-15d%,d", "RPS/thread", relpFlooder.getTotalRecordsSent()/testDuration/flooderThreads, frameConsumer.receivedRecords.get()/testDuration/serverThreads));
     }
 
     private static class FrameConsumer implements Consumer<FrameContext> {
-        final AtomicLong atomicLong = new AtomicLong();
+        final AtomicLong receivedRecords = new AtomicLong();
+        final AtomicLong receivedBytes = new AtomicLong();
         @Override
         public void accept(FrameContext frameServerRX) {
-            atomicLong.incrementAndGet();
+            receivedRecords.incrementAndGet();
+            receivedBytes.addAndGet(frameServerRX.relpFrame().payload().size());
         }
     }
 }


### PR DESCRIPTION
~~WIP: rlp_09 requires the librarized version, do not merge before that is done and updated~~

Allows running automatic benchmarks for asymmetric input:output thread counts. The messages sent and received *SHOULD* always be the same here but both are printed for consistency reasons

```sh
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Running <2> server and <2> input threads test for <60> seconds
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest -                Flooder        Server
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Threads        2              2
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Records        2,399,186      2,399,186
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - RPS            39,986         39,986
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - RPS/thread     19,993         19,993
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Running <4> server and <4> input threads test for <60> seconds
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest -                Flooder        Server
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Threads        4              4
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - Records        4,263,760      4,263,760
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - RPS            71,062         71,062
[main] INFO com.teragrep.rlp_03.ManualBenchmarkTest - RPS/thread     17,765         17,765
```